### PR TITLE
use_branding patch

### DIFF
--- a/nextcloud.nsi
+++ b/nextcloud.nsi
@@ -558,6 +558,28 @@ Section -post
    WriteRegDWORD ${MEMENTO_REGISTRY_ROOT} "${MEMENTO_REGISTRY_KEY}" "NoRepair" "1"
 
 
+   ;Respect user choices for the client's first launch.
+   Var /GLOBAL configFileName
+   StrCpy $configFileName "$APPDATA\${APPLICATION_NAME}\${APPLICATION_SHORTNAME}.cfg"
+
+   !ifdef OPTION_SECTION_SC_SHELL_EXT
+      Var /GLOBAL showInExplorerNavigationPane
+
+      ${If} ${SectionIsSelected} ${SEC_SHELL_EXT}
+         StrCpy $showInExplorerNavigationPane "true"
+      ${Else}
+         StrCpy $showInExplorerNavigationPane "false"
+      ${EndIf}
+
+      CreateDirectory "$APPDATA\${APPLICATION_NAME}"
+
+      SetShellVarContext all
+      DeleteINIStr "$configFileName" "General" "showInExplorerNavigationPane"
+      WriteIniStr "$configFileName" "General" "showInExplorerNavigationPane" "$showInExplorerNavigationPane"
+      SetShellVarContext current
+   !endif
+
+
    SetDetailsPrint textonly
    DetailPrint $UNINSTALLER_FINISHED_Detail
 SectionEnd

--- a/nextcloud.nsi
+++ b/nextcloud.nsi
@@ -433,7 +433,7 @@ Section "${APPLICATION_NAME}" SEC_APPLICATION
       !finalize '"${CURRENT_PATH}\sign.bat" "%1"'
    !endif
    !if ${UPLOAD_BUILD} != 0
-      !finalize '"${CURRENT_PATH}\upload.bat" %1'  ; note: %1 quotes intenionally removed!
+      !finalize '"${CURRENT_PATH}\upload.bat" %1'  ; note: %1 quotes intentionally removed!
    !endif
 SectionEnd
 !endif ;IS_INNER_SIGN_UNINSTALLER

--- a/nextcloud.nsi
+++ b/nextcloud.nsi
@@ -5,6 +5,7 @@
 !define APPLICATION_VENDOR "$%APPLICATION_VENDOR%"
 !define APPLICATION_EXECUTABLE "nextcloud.exe"
 !define APPLICATION_CMD_EXECUTABLE "nextcloudcmd.exe"
+!define APPLICATION_CONFIG_FILE "nextcloud.cfg"
 !define APPLICATION_DOMAIN "nextcloud.com"
 !define APPLICATION_LICENSE ""
 !define WIN_SETUP_BITMAP_PATH "$%PROJECT_PATH%\desktop\admin\win\nsi"
@@ -560,7 +561,7 @@ Section -post
 
    ;Respect user choices for the client's first launch.
    Var /GLOBAL configFileName
-   StrCpy $configFileName "$APPDATA\${APPLICATION_NAME}\${APPLICATION_SHORTNAME}.cfg"
+   StrCpy $configFileName "$APPDATA\${APPLICATION_NAME}\${APPLICATION_CONFIG_FILE}"
 
    !ifdef OPTION_SECTION_SC_SHELL_EXT
       Var /GLOBAL showInExplorerNavigationPane

--- a/nextcloud.nsi
+++ b/nextcloud.nsi
@@ -1,10 +1,14 @@
 ;Nextcloud installer script.
+!if "$%USE_BRANDING%" == "1" 
+	!define APPLICATION_NAME "$%APP_NAME%"
+!else
+    !define APPLICATION_NAME "nextcloud"
+!endif
 
-!define APPLICATION_SHORTNAME "nextcloud"
-!define APPLICATION_NAME "Nextcloud"
+!define APPLICATION_SHORTNAME "${APPLICATION_NAME}"
 !define APPLICATION_VENDOR "$%APPLICATION_VENDOR%"
-!define APPLICATION_EXECUTABLE "nextcloud.exe"
-!define APPLICATION_CMD_EXECUTABLE "nextcloudcmd.exe"
+!define APPLICATION_EXECUTABLE "${APPLICATION_NAME}.exe"
+!define APPLICATION_CMD_EXECUTABLE "${APPLICATION_NAME}cmd.exe"
 !define APPLICATION_CONFIG_FILE "nextcloud.cfg"
 !define APPLICATION_DOMAIN "nextcloud.com"
 !define APPLICATION_LICENSE ""

--- a/single-build-desktop.bat
+++ b/single-build-desktop.bat
@@ -151,6 +151,20 @@ if "%BUILD_TYPE%" == "Debug" (
 ) else (
     set WINDEPLOYQT_BUILD_TYPE=release
 )
+
+if "%USE_BRANDING%" == "1" (
+     start "mv nextcloud" /B  /wait mv "%MY_INSTALL_PATH%/bin/nextcloud.exe" "%MY_INSTALL_PATH%/bin/%APP_NAME%.exe"
+     start "mv nextcloudcmd" /B  /wait mv "%MY_INSTALL_PATH%/bin/nextcloudcmd.exe" "%MY_INSTALL_PATH%/bin/%APP_NAME%cmd.exe"	 
+     if exist "%MY_INSTALL_PATH%/bin/nextcloud/" (
+	    start "mkdir " /B /wait "%WIN_GIT_PATH%\usr\bin\mkdir.exe" -p "%MY_INSTALL_PATH%/bin/%APP_NAME_SANITIZED%/"
+		start "mv bin files" /B /wait mv "%MY_INSTALL_PATH%/bin/nextcloud/"* "%MY_INSTALL_PATH%/bin/%APP_NAME_SANITIZED%/"
+		start "rm -rf" /B /wait rm -drf "%MY_INSTALL_PATH%/bin/nextcloud/"
+	    start "mkdir %MY_INSTALL_PATH%/config/%APP_NAME%/" /B /wait "%WIN_GIT_PATH%\usr\bin\mkdir.exe" -p "%MY_INSTALL_PATH%/config/%APP_NAME%/"
+		start "mv config files" /B  /wait mv "%MY_INSTALL_PATH%/config/nextcloud/"* "%MY_INSTALL_PATH%/config/%APP_NAME%/"
+		start "rm -rf" /B /wait rm -drf "%MY_INSTALL_PATH%/config/nextcloud/"
+     )		
+)
+
 echo "* Run windeployqt to collect all %APP_NAME%.exe dependencies and output it to %MY_QT_DEPLOYMENT_PATH%/."
 start "windeployqt" /B /wait windeployqt.exe --%WINDEPLOYQT_BUILD_TYPE% --compiler-runtime "%MY_INSTALL_PATH%/bin/%APP_NAME%.exe" --dir "%MY_QT_DEPLOYMENT_PATH%/"
 if %ERRORLEVEL% neq 0 goto onError

--- a/single-build-desktop.bat
+++ b/single-build-desktop.bat
@@ -158,10 +158,10 @@ if "%USE_BRANDING%" == "1" (
      if exist "%MY_INSTALL_PATH%/bin/nextcloud/" (
 	    start "mkdir " /B /wait "%WIN_GIT_PATH%\usr\bin\mkdir.exe" -p "%MY_INSTALL_PATH%/bin/%APP_NAME_SANITIZED%/"
 		start "mv bin files" /B /wait mv "%MY_INSTALL_PATH%/bin/nextcloud/"* "%MY_INSTALL_PATH%/bin/%APP_NAME_SANITIZED%/"
-		start "rm -rf" /B /wait rm -drf "%MY_INSTALL_PATH%/bin/nextcloud/"
+		start "rm branded dir" /B /wait rm -drf "%MY_INSTALL_PATH%/bin/nextcloud/"
 	    start "mkdir %MY_INSTALL_PATH%/config/%APP_NAME%/" /B /wait "%WIN_GIT_PATH%\usr\bin\mkdir.exe" -p "%MY_INSTALL_PATH%/config/%APP_NAME%/"
 		start "mv config files" /B  /wait mv "%MY_INSTALL_PATH%/config/nextcloud/"* "%MY_INSTALL_PATH%/config/%APP_NAME%/"
-		start "rm -rf" /B /wait rm -drf "%MY_INSTALL_PATH%/config/nextcloud/"
+		start "rm branded dir" /B /wait rm -drf "%MY_INSTALL_PATH%/config/nextcloud/"
      )		
 )
 

--- a/single-build-installer-collect.bat
+++ b/single-build-installer-collect.bat
@@ -226,7 +226,7 @@ if "%USE_CODE_SIGNING%" == "0" (
             "shellext/OCUtil.dll"
             "%APP_NAME_SANITIZED%.exe"
             "%APP_NAME_SANITIZED%cmd.exe"
-            "%APP_NAME_SANITIZED%sync.dll"
+            "nextcloudsync.dll"
             "OCContextMenu.dll"
             "OCOverlays.dll"
             "ocsync.dll"


### PR DESCRIPTION
These patch is related to the issue #4
If you set USE_BRANDING = 1 the building process cannot finish because of this line

start "windeployqt" /B /wait windeployqt.exe --%WINDEPLOYQT_BUILD_TYPE% --compiler-runtime "%MY_INSTALL_PATH%/bin/%APP_NAME%.exe" --dir "%MY_QT_DEPLOYMENT_PATH%/"

This %APP_NAME%.exe is not found.
The pull request rename files and directories after the compilation process. The main disadvantage is

nextcloud.cfg and nextcloudsync.dll cannot be rebranded otherwise the nextcloud.exe (the new one rebranded) cannot find the dll and cfg