### PR TITLE
Qt 5.12.8 with QML (Desktop 2.7) for VS2019

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -41,7 +41,6 @@ Rem ****************************************************************************
 
 echo "***** build qtkeychain."
 start "build-qtkeychain.bat %BUILD_TYPE%" /D "%PROJECT_PATH%/" /B /wait "%~dp0/build-qtkeychain.bat" %BUILD_TYPE%
-echo "test"
 if %ERRORLEVEL% neq 0 goto onError
 
 

--- a/defaults.inc.bat
+++ b/defaults.inc.bat
@@ -32,7 +32,7 @@ rem Comma separated list of build targets (default: Win64, Win32)
 if "%BUILD_TARGETS%" == ""                  set BUILD_TARGETS=Win64,Win32
 
 if "%PROJECT_PATH%" == ""                   set PROJECT_PATH=c:/Nextcloud/client-building
-if "%QT_PATH%" == ""                        set QT_PATH=c:/Qt/5.12.5
+if "%QT_PATH%" == ""                        set QT_PATH=c:/Qt/5.12.8
 
                                             set PATH=c:/Nextcloud/tools/cmake/bin;c:/Nextcloud/tools;C:/Program Files (x86)/NSIS;%PATH%
 

--- a/defaults.inc.bat
+++ b/defaults.inc.bat
@@ -40,10 +40,10 @@ if "%OPENSSL_PATH%" == ""                   set OPENSSL_PATH=c:/OpenSSL
 
 if "%Png2Ico_EXECUTABLE%" == ""             set Png2Ico_EXECUTABLE=c:/Nextcloud/tools/png2ico.exe
 
-if "%VS_VERSION%" == ""						set VS_VERSION=2019
+if "%VS_VERSION%" == ""                     set VS_VERSION=2019
 
 Rem Required for Qt's windeployqt to find the VC Redist Setup (and for auto-discovery of signtool.exe)
-if "%VCINSTALLDIR%" == ""	(
+if "%VCINSTALLDIR%" == "" (
 	if "%VS_VERSION%" == "2017"	(
 		set VCINSTALLDIR=C:\Program^ Files^ ^(x86^)\Microsoft^ Visual^ Studio\2017\Community\VC
 	)

--- a/single-build-desktop.bat
+++ b/single-build-desktop.bat
@@ -122,14 +122,20 @@ if "%PULL_DESKTOP%" == "1" (
     )
     if !ERRORLEVEL! neq 0 goto onError
 
-    echo "* git pull at %MY_REPO%/."
-    start "git pull" /D "%MY_REPO%/" /B /wait git pull --tags origin master
+    echo "* git pull master at %MY_REPO%/."
+    start "git pull master" /D "%MY_REPO%/" /B /wait git pull --tags origin master
 )
 if %ERRORLEVEL% neq 0 goto onError
 
 if "%CHECKOUT_DESKTOP%" == "1" (
     echo "* git checkout %TAG% at %MY_REPO%/."
     start "git checkout %TAG%" /D "%MY_REPO%/" /B /wait git checkout %TAG%
+    if !ERRORLEVEL! neq 0 goto onError
+
+    if "%PULL_DESKTOP%" == "1" (
+        echo "* git pull %TAG% at %MY_REPO%/."
+        start "git pull %TAG%" /D "%MY_REPO%/" /B /wait git pull
+    )
 )
 if %ERRORLEVEL% neq 0 goto onError
 

--- a/single-build-desktop.bat
+++ b/single-build-desktop.bat
@@ -160,7 +160,7 @@ if "%BUILD_TYPE%" == "Debug" (
     set WINDEPLOYQT_BUILD_TYPE=release
 )
 echo "* Run windeployqt to collect all %APP_NAME%.exe dependencies and output it to %MY_QT_DEPLOYMENT_PATH%/."
-start "windeployqt" /B /wait windeployqt.exe --%WINDEPLOYQT_BUILD_TYPE% --compiler-runtime "%MY_INSTALL_PATH%/bin/%APP_NAME%.exe" --dir "%MY_QT_DEPLOYMENT_PATH%/"
+start "windeployqt" /B /wait windeployqt.exe --%WINDEPLOYQT_BUILD_TYPE% --compiler-runtime "%MY_INSTALL_PATH%/bin/%APP_NAME%.exe" --dir "%MY_QT_DEPLOYMENT_PATH%/" --qmldir "%MY_REPO%/src/gui"
 if %ERRORLEVEL% neq 0 goto onError
 
 Rem ******************************************************************************************


### PR DESCRIPTION
Continuation of #10.

Upgrades:
- Qt 5.12.8
- QML for Desktop 2.7
- OpenSSL 1.1.1g
- Pull desktop repo tag after checkout

TODO:

- [ ] Update Readme.md