### PR TITLE
Fix VC Redist filenames in the installer script (VS2019 changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This allows you to easily build the desktop client for 64-bit and 32-bit Windows.
 
+## Update: 2020-06-13
+
+The VC Runtime redistributable filenames have changed in VS 2019.
+
+If you still want to use VS 2017 you may have to change them, see: https://github.com/nextcloud/client-building/pull/28
+
 ## Update: 2020-06-11
 
 Upgrades / new default versions:

--- a/nextcloud.nsi
+++ b/nextcloud.nsi
@@ -326,12 +326,12 @@ FunctionEnd
 
 Function InstallRedistributables
    ${If} ${RunningX64}
-      ExecWait '"$OUTDIR\vcredist_x64.exe" /install /quiet /norestart'
+      ExecWait '"$OUTDIR\vc_redist.x64.exe" /install /quiet /norestart'
    ${Else}
-      ExecWait '"$OUTDIR\vcredist_x86.exe" /install /quiet /norestart'
+      ExecWait '"$OUTDIR\vc_redist.x86.exe" /install /quiet /norestart'
    ${EndIf}
-   Delete "$OUTDIR\vcredist_x86.exe"
-   Delete "$OUTDIR\vcredist_x64.exe"
+   Delete "$OUTDIR\vc_redist.x86.exe"
+   Delete "$OUTDIR\vc_redist.x64.exe"
 FunctionEnd
 
 ##############################################################################


### PR DESCRIPTION
MS changed their Runtime's filenames, like:
  `vcredist_x64.exe` -> `vc_redist.x64.exe`

Related Desktop issue: nextcloud/desktop#978