### PR TITLE
VC Redist for version 3.0 (VS 2019), prepare for MSI

### DIFF
--- a/nextcloud.nsi
+++ b/nextcloud.nsi
@@ -324,15 +324,16 @@ Function EnsureOwncloudShutdown
    !insertmacro CheckAndConfirmEndProcess "${APPLICATION_EXECUTABLE}"
 FunctionEnd
 
-Function InstallRedistributables
-   ${If} ${RunningX64}
-      ExecWait '"$OUTDIR\vc_redist.x64.exe" /install /quiet /norestart'
-   ${Else}
-      ExecWait '"$OUTDIR\vc_redist.x86.exe" /install /quiet /norestart'
-   ${EndIf}
-   Delete "$OUTDIR\vc_redist.x86.exe"
-   Delete "$OUTDIR\vc_redist.x64.exe"
-FunctionEnd
+;Redist DLLs now already deployed in installation dir and shellext statically linked
+;Function InstallRedistributables
+;   ${If} ${RunningX64}
+;      ExecWait '"$OUTDIR\vc_redist.x64.exe" /install /quiet /norestart'
+;   ${Else}
+;      ExecWait '"$OUTDIR\vc_redist.x86.exe" /install /quiet /norestart'
+;   ${EndIf}
+;   Delete "$OUTDIR\vc_redist.x86.exe"
+;   Delete "$OUTDIR\vc_redist.x64.exe"
+;FunctionEnd
 
 ##############################################################################
 #                                                                            #
@@ -446,7 +447,7 @@ SectionEnd
       DetailPrint $OPTION_SECTION_SC_SHELL_EXT_DetailPrint
       ;File "${VCREDISTPATH}\vcredist_x86.exe"  ;now collected by windeployqt
       ;File "${VCREDISTPATH}\vcredist_x64.exe"  ;now collected by windeployqt
-      Call InstallRedistributables
+      ;Call InstallRedistributables             ;Redist DLLs now already deployed in installation dir and shellext statically linked
       CreateDirectory "$INSTDIR\shellext"
       !define LIBRARY_COM
       !define LIBRARY_SHELL_EXTENSION

--- a/single-build-installer-collect.bat
+++ b/single-build-installer-collect.bat
@@ -194,6 +194,22 @@ echo "* copy optional extra resources (dll's, etc.) from %EXTRA_DEPLOY_PATH%/."
 if %ERRORLEVEL% neq 0 goto onError
 :skipDeployExtra
 
+Rem VC Environment Variables
+echo "** Calling vcvars64.bat to get the VC env vars:"
+call "%VCINSTALLDIR%\Auxiliary\Build\vcvars64.bat"
+
+Rem VC Redist
+echo "* copy VC Redist Runtime DLLs from %VCToolsRedistDir%/."
+if "%BUILD_ARCH%" == "Win64" (
+    start "copy VC Redist x64" /D "%MY_COLLECT_PATH%/" /B /wait cp -af "%VCToolsRedistDir%/x64/Microsoft.VC142.CRT/"* "%MY_COLLECT_PATH%/"
+) else (
+    start "copy VC Redist x86" /D "%MY_COLLECT_PATH%/" /B /wait cp -af "%VCToolsRedistDir%/x86/Microsoft.VC142.CRT/"* "%MY_COLLECT_PATH%/"
+)
+if %ERRORLEVEL% neq 0 goto onError
+
+echo "* remove VC Redist installer(s) from %MY_COLLECT_PATH%/."
+start "remove vc*redist*.exe" /D "%MY_COLLECT_PATH%/" /B /wait rm -f "%MY_COLLECT_PATH%"/vc*redist*.exe
+
 Rem ******************************************************************************************
 rem 			"code signing"
 Rem ******************************************************************************************
@@ -201,8 +217,7 @@ Rem ****************************************************************************
 if "%USE_CODE_SIGNING%" == "0" (
     echo "** Don't sign: Code signing is disabled by USE_CODE_SIGNING"
 ) else (
-    echo "** Calling vcvars64.bat to add signtool to the PATH:"
-    call "%VCINSTALLDIR%\Auxiliary\Build\vcvars64.bat"
+    echo "** Trying to find signtool in the PATH (VC env vars):"
 
     for %%i in (signtool.exe) do @set SIGNTOOL=%%~$PATH:i
 


### PR DESCRIPTION
Use the new VS 2019 env var `%VCToolsRedistDir%` to get the Redist deployment DLL path and copy them for the installer.
The Qt deployment tool missed some of those.

We don't need to ship and run the VC Redist installer anymore, since the 3.0 shell extensions are now staically linked and all VC DLLs will be in the program directory.

Also see: https://docs.microsoft.com/en-us/cpp/windows/redistributing-visual-cpp-files?view=vs-2019