### PR TITLE
Copy qt5keychaind.dll in debug builds & set QTKEYCHAIN_LIBRARY depend…

### DIFF
--- a/build-desktop.bat
+++ b/build-desktop.bat
@@ -24,11 +24,7 @@ for %%G in (%BUILD_TARGETS%) do (
     set ZLIB_PATH=%PROJECT_PATH%/libs/%BUILD_TYPE%/zlib/%%G
 
     set QTKEYCHAIN_INCLUDE_DIR=!QTKEYCHAIN_PATH!/include/qt5keychain
-    if "%BUILD_TYPE%" == "Debug" (
-        set QTKEYCHAIN_LIBRARY=!QTKEYCHAIN_PATH!/lib/qt5keychaind.lib
-    ) else (
-        set QTKEYCHAIN_LIBRARY=!QTKEYCHAIN_PATH!/lib/qt5keychain.lib
-    )
+    set QTKEYCHAIN_LIBRARY=!QTKEYCHAIN_PATH!/lib/qt5keychain!DLL_SUFFIX!.lib
     set OPENSSL_INCLUDE_DIR=!OPENSSL_ROOT_DIR!/include
     set OPENSSL_LIBRARIES=!OPENSSL_ROOT_DIR!/lib
     set ZLIB_INCLUDE_DIR=!ZLIB_PATH!/include

--- a/build-desktop.bat
+++ b/build-desktop.bat
@@ -24,7 +24,11 @@ for %%G in (%BUILD_TARGETS%) do (
     set ZLIB_PATH=%PROJECT_PATH%/libs/%BUILD_TYPE%/zlib/%%G
 
     set QTKEYCHAIN_INCLUDE_DIR=!QTKEYCHAIN_PATH!/include/qt5keychain
-    set QTKEYCHAIN_LIBRARY=!QTKEYCHAIN_PATH!/lib/qt5keychain.lib
+    if "%BUILD_TYPE%" == "Debug" (
+        set QTKEYCHAIN_LIBRARY=!QTKEYCHAIN_PATH!/lib/qt5keychaind.lib
+    ) else (
+        set QTKEYCHAIN_LIBRARY=!QTKEYCHAIN_PATH!/lib/qt5keychain.lib
+    )
     set OPENSSL_INCLUDE_DIR=!OPENSSL_ROOT_DIR!/include
     set OPENSSL_LIBRARIES=!OPENSSL_ROOT_DIR!/lib
     set ZLIB_INCLUDE_DIR=!ZLIB_PATH!/include

--- a/build-qtkeychain.bat
+++ b/build-qtkeychain.bat
@@ -13,6 +13,12 @@ rem Reference: https://ss64.com/nt/setlocal.html
 rem Reference: https://ss64.com/nt/start.html
 
 for %%G in (%BUILD_TARGETS%) do (
+    if "%BUILD_TYPE%" == "Debug" (
+        set DLL_SUFFIX=d
+    ) else (
+        set DLL_SUFFIX=
+    )
+
     echo "**** build qtkeychain for %%G (%~nx0)."
     start "single-build-qtkeychain.bat %BUILD_TYPE% %%G" /D "%PROJECT_PATH%/" /B /wait "%~dp0/single-build-qtkeychain.bat" %BUILD_TYPE% %%G
 

--- a/single-build-installer-collect.bat
+++ b/single-build-installer-collect.bat
@@ -101,7 +101,7 @@ Rem Note: Force the use Git Bash's mkdir.exe, usually found in C:\Program Files\
 if %ERRORLEVEL% neq 0 goto onError
 
 Rem Qt dependencies
-echo "* copy Qt libs (including qt5keychain.dll)."
+echo "* copy Qt libs (including qt5keychain%DLL_SUFFIX%.dll)."
 start "copy Qt libs" /D "%MY_COLLECT_PATH%/" /B /wait cp -af "%MY_INSTALL_PATH%/qt-libs/"* "%MY_COLLECT_PATH%/"
 if %ERRORLEVEL% neq 0 goto onError
 
@@ -238,7 +238,7 @@ if "%USE_CODE_SIGNING%" == "0" (
             "%APP_NAME_SANITIZED%cmd.exe"
             "%APP_NAME_SANITIZED%sync.dll"
             "ocsync.dll"
-            "qt5keychain.dll"
+            "qt5keychain%DLL_SUFFIX%.dll"
             "%LIBCRYPTO_DLL_FILENAME%"
             "%LIBSSL_DLL_FILENAME%"
             "zlib%DLL_SUFFIX%.dll"

--- a/single-build-qtkeychain.bat
+++ b/single-build-qtkeychain.bat
@@ -32,6 +32,8 @@ echo "* TAG %TAG%"
 echo "* PULL_QTKEYCHAIN %PULL_QTKEYCHAIN%"
 echo "* CHECKOUT_QTKEYCHAIN %CHECKOUT_QTKEYCHAIN%"
 
+echo "* DLL_SUFFIX=%DLL_SUFFIX%"
+
 echo "* MY_REPO=%MY_REPO%"
 echo "* MY_BUILD_PATH=%MY_BUILD_PATH%"
 echo "* MY_INSTALL_PATH=%MY_INSTALL_PATH%"
@@ -108,13 +110,8 @@ echo "* Run cmake to compile and install."
 start "cmake build" /D "%MY_BUILD_PATH%" /B /wait cmake --build . --config %BUILD_TYPE% --target install
 if %ERRORLEVEL% neq 0 goto onError
 
-if "%BUILD_TYPE%" == "Debug" (
-    echo "* Copy qt5keychaind.dll to %QT_BIN_PATH%/ for windeployqt to find it."
-	start "copy qt5keychaind.dll for windeployqt" /B /wait cp -f "%MY_INSTALL_PATH%/bin/qt5keychaind.dll" "%QT_BIN_PATH%/"
-) else (
-    echo "* Copy qt5keychain.dll to %QT_BIN_PATH%/ for windeployqt to find it."
-    start "copy qt5keychain.dll for windeployqt" /B /wait cp -f "%MY_INSTALL_PATH%/bin/qt5keychain.dll" "%QT_BIN_PATH%/"
-)
+echo "* Copy qt5keychain%DLL_SUFFIX%.dll to %QT_BIN_PATH%/ for windeployqt to find it."
+start "copy qt5keychain%DLL_SUFFIX%.dll for windeployqt" /B /wait cp -f "%MY_INSTALL_PATH%/bin/qt5keychain%DLL_SUFFIX%.dll" "%QT_BIN_PATH%/"
 if %ERRORLEVEL% neq 0 goto onError
 
 Rem ******************************************************************************************

--- a/single-build-qtkeychain.bat
+++ b/single-build-qtkeychain.bat
@@ -108,8 +108,13 @@ echo "* Run cmake to compile and install."
 start "cmake build" /D "%MY_BUILD_PATH%" /B /wait cmake --build . --config %BUILD_TYPE% --target install
 if %ERRORLEVEL% neq 0 goto onError
 
-echo "* Copy qt5keychain.dll to %QT_BIN_PATH%/ for windeployqt to find it."
-start "copy qt5keychain.dll for windeployqt" /B /wait cp -f "%MY_INSTALL_PATH%/bin/qt5keychain.dll" "%QT_BIN_PATH%/"
+if "%BUILD_TYPE%" == "Debug" (
+    echo "* Copy qt5keychaind.dll to %QT_BIN_PATH%/ for windeployqt to find it."
+	start "copy qt5keychaind.dll for windeployqt" /B /wait cp -f "%MY_INSTALL_PATH%/bin/qt5keychaind.dll" "%QT_BIN_PATH%/"
+) else (
+    echo "* Copy qt5keychain.dll to %QT_BIN_PATH%/ for windeployqt to find it."
+    start "copy qt5keychain.dll for windeployqt" /B /wait cp -f "%MY_INSTALL_PATH%/bin/qt5keychain.dll" "%QT_BIN_PATH%/"
+)
 if %ERRORLEVEL% neq 0 goto onError
 
 Rem ******************************************************************************************


### PR DESCRIPTION
…ing on current build target (debug/release)

Signed-off-by: Dominique Fuchs <32204802+DominiqueFuchs@users.noreply.github.com>

Effects:

- Script doesn't bail out when building with only Debug (b/c qtkeychain.xxx not found, unaware of qtkeychaind.xxx)
- The debug obj is actually used within debug builds