### PR TITLE
Use CreateMutexW instead of CreateMutexA to check if process is running.

### DIFF
--- a/nextcloud.nsi
+++ b/nextcloud.nsi
@@ -833,7 +833,7 @@ Function .onInit
       ${EndSwitch}
 
    ;Prevent multiple instances.
-   System::Call 'kernel32::CreateMutexA(i 0, i 0, t "${APPLICATION_SHORTNAME}Installer") i .r1 ?e'
+   System::Call 'kernel32::CreateMutexW(i 0, i 0, t "${APPLICATION_SHORTNAME}Installer") i .r1 ?e'
    Pop $R0
    StrCmp $R0 0 +3
       MessageBox MB_OK|MB_ICONEXCLAMATION $INIT_INSTALLER_RUNNING
@@ -912,7 +912,7 @@ Function un.onInit
       ${EndSwitch}
 
    ;Prevent multiple instances.
-   System::Call 'kernel32::CreateMutexA(i 0, i 0, t "${APPLICATION_SHORTNAME}Uninstaller") i .r1 ?e'
+   System::Call 'kernel32::CreateMutexW(i 0, i 0, t "${APPLICATION_SHORTNAME}Uninstaller") i .r1 ?e'
    Pop $R0
    StrCmp $R0 0 +3
       MessageBox MB_OK|MB_ICONEXCLAMATION $INIT_UNINSTALLER_RUNNING


### PR DESCRIPTION
Fix for nextcloud/desktop/issues/2606: this change is needed since
we are using Unicode NSIS.

For reference: https://nsis.sourceforge.io/mediawiki/index.php?title=Allow_only_one_installer_instance&oldid=22437#Unicode_warning
