### PR TITLE
After building qtkeychain go back to master branch.

### DIFF
--- a/single-build-qtkeychain.bat
+++ b/single-build-qtkeychain.bat
@@ -110,6 +110,9 @@ echo "* Run cmake to compile and install."
 start "cmake build" /D "%MY_BUILD_PATH%" /B /wait cmake --build . --config %BUILD_TYPE% --target install
 if %ERRORLEVEL% neq 0 goto onError
 
+echo "* go back to master: git checkout master at %MY_REPO%/."
+start "git checkout master /D "%MY_REPO%/" /B /wait git checkout master
+
 echo "* Copy qt5keychain%DLL_SUFFIX%.dll to %QT_BIN_PATH%/ for windeployqt to find it."
 start "copy qt5keychain%DLL_SUFFIX%.dll for windeployqt" /B /wait cp -f "%MY_INSTALL_PATH%/bin/qt5keychain%DLL_SUFFIX%.dll" "%QT_BIN_PATH%/"
 if %ERRORLEVEL% neq 0 goto onError


### PR DESCRIPTION
It avoids the git error "You are not currently on a branch." when building Win32 
right after building Win64.

Signed-off-by: Camila <hello@camila.codes>