### PR TITLE
Fix Linux daily build.

### DIFF
--- a/linux/build-appimage-daily.sh
+++ b/linux/build-appimage-daily.sh
@@ -46,7 +46,7 @@ make DESTDIR=/app install
 # Move stuff around
 cd /app
 
-mv ./usr/lib/x86_64-linux-gnu/nextcloud/* ./usr/lib/x86_64-linux-gnu/
+mv ./usr/lib/x86_64-linux-gnu/libnextcloud*.* ./usr/lib/x86_64-linux-gnu/
 mv ./usr/lib/x86_64-linux-gnu/* ./usr/lib/
 rm -rf ./usr/lib/nextcloud
 rm -rf ./usr/lib/cmake


### PR DESCRIPTION
The error was
mv: cannot stat './usr/lib/x86_64-linux-gnu/nextcloud/*': No such file or directory
Because the lib files have libnextcloud in the name now.

Signed-off-by: Camila <hello@camila.codes>