### PR TITLE
Fix daily builds for Linux

### DIFF
--- a/linux/build-appimage-daily.sh
+++ b/linux/build-appimage-daily.sh
@@ -69,8 +69,8 @@ cp ./usr/share/icons/hicolor/512x512/apps/Nextcloud.png . # Workaround for linux
 
 
 # Because distros need to get their shit together
-cp -R /lib/x86_64-linux-gnu/libssl.so* ./usr/lib/
-cp -R /lib/x86_64-linux-gnu/libcrypto.so* ./usr/lib/
+cp -R /usr/lib/x86_64-linux-gnu/libssl.so* ./usr/lib/
+cp -R /usr/lib/x86_64-linux-gnu/libcrypto.so* ./usr/lib/
 cp -P /usr/local/lib/libssl.so* ./usr/lib/
 cp -P /usr/local/lib/libcrypto.so* ./usr/lib/
 

--- a/linux/build-daily.sh
+++ b/linux/build-daily.sh
@@ -12,7 +12,7 @@ docker run \
     --name desktop-$DATE \
     -v $DIR:/input \
     -v ~/output/$DATE:/output \
-    ghcr.io/nextcloud/continuous-integration-client-appimage:client-appimage-1 \
+    ghcr.io/nextcloud/continuous-integration-client-appimage:client-appimage-2 \
     /input/build-appimage-daily.sh $(id -u)
 
 #Save the logs!


### PR DESCRIPTION
Fix 'Could not find a configuration file for package "Qt5" that is compatible' error and 'cp: cannot stat '/lib/x86_64-linux-gnu/libssl.so*': No such file or directory'.