### PR TITLE
set right path for Qt

### DIFF
--- a/defaults.inc.bat
+++ b/defaults.inc.bat
@@ -33,7 +33,7 @@ if "%BUILD_TARGETS%" == ""                  set BUILD_TARGETS=Win64,Win32
 
 if "%PROJECT_PATH%" == ""                   set PROJECT_PATH=c:/Nextcloud/client-building
 
-if "%QT_PATH%" == ""                        set QT_PATH=d:/Qt/5.15.2
+if "%QT_PATH%" == ""                        set QT_PATH=c:/Qt/5.15.2
 if "%QT_VS_VERSION%" == ""                  set QT_VS_VERSION=2019
 
                                             set PATH=c:/Nextcloud/tools/cmake/bin;c:/Nextcloud/tools;C:/Program Files (x86)/NSIS;%PATH%


### PR DESCRIPTION
As far the readme file goes, Qt was install under "C" drive. If i don't changed it to correct path then i got the following errors.

CMake Error at C:/Firora-Cloud/tools/cmake/share/cmake-3.21/Modules/FindQt4.cmake:1314 (message):
  Found unsuitable Qt version "" from NOTFOUND, this code requires Qt 4.x
Call Stack (most recent call first):
  CMakeLists.txt:97 (find_package)