### PR TITLE
Change CMake version in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Optional:
 
   Note: MSVC 2017 is binary compatible with VS 2019, so don't be confused ;-)
 
-- [ ] CMake 3.14.x (choose the ZIP version, extract and rename to: C:\Nextcloud\tools\cmake):
+- [ ] CMake 3.16.x (choose the ZIP version, extract and rename to: C:\Nextcloud\tools\cmake):
       https://cmake.org/download/
 
 - [ ] Png2Icon - you need to use this version: https://download.nextcloud.com/desktop/development/Windows/tools/png2ico.exe


### PR DESCRIPTION
The Nextcloud Desktop client has now a minimum requirement for CMake 3.16

https://github.com/nextcloud/desktop/blob/master/CMakeLists.txt#L1:
```cmake
cmake_minimum_required(VERSION 3.16)
```