### PR TITLE
copy extra external DLLs from C:\Program Files (x86)\ECM\bin

### DIFF
--- a/single-build-installer-collect.bat
+++ b/single-build-installer-collect.bat
@@ -186,6 +186,10 @@ Rem also copy e.g.: %OPENSSL_ROOT_DIR%/bin/msvcr120.dll
 Rem zlib
 echo "* copy zlib%DLL_SUFFIX%.dll."
 start "copy zlib%DLL_SUFFIX%.dll" /D "%MY_COLLECT_PATH%/" /B /wait cp -af "%ZLIB_PATH%/bin/zlib%DLL_SUFFIX%.dll" "%MY_COLLECT_PATH%/"
+if %ERRORLEVEL% neq 0 goto
+
+echo "* copy KArchive files (bin/)."
+start "copy bin/" /D "%MY_COLLECT_PATH%/" /B /wait cp -af "C:\Program Files (x86)\ECM\bin\"* "%MY_COLLECT_PATH%/"
 if %ERRORLEVEL% neq 0 goto onError
 
 Rem deploy-extra: optional extra dll's and other resources


### PR DESCRIPTION
should get KArchive dll in the installer package

Signed-off-by: Matthieu Gallien <matthieu.gallien@nextcloud.com>