### PR TITLE
call signtool with extra parameters to avoid password prompt

### DIFF
--- a/defaults.inc.bat
+++ b/defaults.inc.bat
@@ -108,7 +108,10 @@ Rem Vendor Name: Used for signing, also used by the installer
 if "%APPLICATION_VENDOR%" == ""             set "APPLICATION_VENDOR=Nextcloud GmbH"
 
 Rem PFX Key and Password - it may be a good idea to set the password outside (environment variables)
-if "%CERTIFICATE_HASH%" == ""               set "CERTIFICATE_HASH=9C81A764910FFF3D0B8BC1613EFD72CCF4828EC3"
+if "%CERTIFICATE_FILENAME%" == ""           set "CERTIFICATE_FILENAME="
+if "%CERTIFICATE_CSP%" == ""                set "CERTIFICATE_CSP="
+if "%CERTIFICATE_KEY_CONTAINER_NAME%" == "" set "CERTIFICATE_KEY_CONTAINER_NAME="
+if "%CERTIFICATE_PASSWORD%" == ""           set "CERTIFICATE_PASSWORD="
 
 if "%SIGN_FILE_DIGEST_ALG%" == ""           set "SIGN_FILE_DIGEST_ALG=sha256"
 if "%SIGN_TIMESTAMP_URL%" == ""             set "SIGN_TIMESTAMP_URL=http://timestamp.digicert.com"

--- a/sign.bat
+++ b/sign.bat
@@ -24,7 +24,6 @@ echo "* PROJECT_PATH=%PROJECT_PATH%"
 echo "* SIGNTOOL=%SIGNTOOL%"
 echo "* VCINSTALLDIR=%VCINSTALLDIR%"
 echo "* APPLICATION_VENDOR=%APPLICATION_VENDOR%"
-echo "* CERTIFICATE_HASH=%CERTIFICATE_HASH%"
 echo "* SIGN_FILE_DIGEST_ALG=%SIGN_FILE_DIGEST_ALG%"
 echo "* SIGN_TIMESTAMP_URL=%SIGN_TIMESTAMP_URL%"
 echo "* SIGN_TIMESTAMP_DIGEST_ALG=%SIGN_TIMESTAMP_DIGEST_ALG%"
@@ -43,7 +42,10 @@ if "%USE_CODE_SIGNING%" == "0" (
 
 call :testEnv PROJECT_PATH
 call :testEnv APPLICATION_VENDOR
-call :testEnv CERTIFICATE_HASH
+call :testEnv CERTIFICATE_FILENAME
+call :testEnv CERTIFICATE_CSP
+call :testEnv CERTIFICATE_KEY_CONTAINER_NAME
+call :testEnv CERTIFICATE_PASSWORD
 call :testEnv SIGN_FILE_DIGEST_ALG
 call :testEnv SIGN_TIMESTAMP_URL
 call :testEnv SIGN_TIMESTAMP_DIGEST_ALG
@@ -86,7 +88,7 @@ rem Reference: https://ss64.com/nt/setlocal.html
 rem Reference: https://ss64.com/nt/start.html
 
 echo "* Run signtool on file: %~1"
-start "signtool" /D "%PROJECT_PATH%" /B /wait "%SIGNTOOL%" sign /debug /v /n "%APPLICATION_VENDOR%" /tr "%SIGN_TIMESTAMP_URL%" /td %SIGN_TIMESTAMP_DIGEST_ALG% /fd %SIGN_FILE_DIGEST_ALG% /sha1 "%CERTIFICATE_HASH%" "%~1"
+start "signtool" /D "%PROJECT_PATH%" /B /wait "%SIGNTOOL%" sign /debug /v /tr "%SIGN_TIMESTAMP_URL%" /td %SIGN_TIMESTAMP_DIGEST_ALG% /fd %SIGN_FILE_DIGEST_ALG% /f "%CERTIFICATE_FILENAME%" /csp "%CERTIFICATE_CSP%" /kc "[{{%CERTIFICATE_PASSWORD%}}]=%CERTIFICATE_KEY_CONTAINER_NAME%" "%~1"
 if %ERRORLEVEL% neq 0 goto onError
 
 Rem ******************************************************************************************

--- a/single-build-installer-collect.bat
+++ b/single-build-installer-collect.bat
@@ -57,7 +57,10 @@ call :testEnv EXTRA_DEPLOY_PATH
 if "%USE_CODE_SIGNING%" == "1" (
     call :testEnv VCINSTALLDIR
     call :testEnv APPLICATION_VENDOR
-    call :testEnv CERTIFICATE_HASH
+    call :testEnv CERTIFICATE_FILENAME
+    call :testEnv CERTIFICATE_CSP
+    call :testEnv CERTIFICATE_KEY_CONTAINER_NAME
+    call :testEnv CERTIFICATE_PASSWORD
     call :testEnv SIGN_FILE_DIGEST_ALG
     call :testEnv SIGN_TIMESTAMP_URL
     call :testEnv SIGN_TIMESTAMP_DIGEST_ALG

--- a/single-build-installer-msi.bat
+++ b/single-build-installer-msi.bat
@@ -53,6 +53,18 @@ call :testEnv BUILD_TYPE
 call :testEnv BUILD_ARCH
 call :testEnv BUILD_DATE
 
+if "%USE_CODE_SIGNING%" == "1" (
+    call :testEnv VCINSTALLDIR
+    call :testEnv APPLICATION_VENDOR
+    call :testEnv CERTIFICATE_FILENAME
+    call :testEnv CERTIFICATE_CSP
+    call :testEnv CERTIFICATE_KEY_CONTAINER_NAME
+    call :testEnv CERTIFICATE_PASSWORD
+    call :testEnv SIGN_FILE_DIGEST_ALG
+    call :testEnv SIGN_TIMESTAMP_URL
+    call :testEnv SIGN_TIMESTAMP_DIGEST_ALG
+)
+
 if %ERRORLEVEL% neq 0 goto onError
 
 Rem ******************************************************************************************


### PR DESCRIPTION
set the proper certificate via a filename instead of referring to it via a sha1

will then use the exported certificate file with .cer extension

still this keeps the private key safe on the USB token