### PR TITLE
feat(craftroot): use the new craft root for Qt 6.8.3

### DIFF
--- a/common.inc.bat
+++ b/common.inc.bat
@@ -11,7 +11,7 @@ if "%BUILD_ARCH%" == "Win32" ( set "PATH=%CRAFT_PATH%\bin;%CRAFT_PATH%\dev-utils
 if "%BUILD_ARCH%" == "Win32" ( set "QT_BIN_PATH=%CRAFT_PATH%\bin" )
 if "%BUILD_ARCH%" == "Win32" ( set "QT_PREFIX=%CRAFT_PATH%" )
 
-if "%BUILD_ARCH%" == "Win64" ( set "CRAFT_PATH=c:\CraftRoot-qt6.8.1" )
+if "%BUILD_ARCH%" == "Win64" ( set "CRAFT_PATH=c:\Nextcloud\windows-msvc2022_64-cl" )
 if "%BUILD_ARCH%" == "Win64" ( set "QT_PATH=%CRAFT_PATH%" )
 if "%BUILD_ARCH%" == "Win64" ( set "PATH=%CRAFT_PATH%\bin;%CRAFT_PATH%\dev-utils\bin;%PATH%" )
 if "%BUILD_ARCH%" == "Win64" ( set "QT_BIN_PATH=%CRAFT_PATH%\bin" )


### PR DESCRIPTION
the new craft root is in c:\Nextcloud\windows-msvc2022_64-cl