### PR TITLE
chore: by default we do a RelWithDebInfo build

### DIFF
--- a/defaults.inc.bat
+++ b/defaults.inc.bat
@@ -20,7 +20,7 @@ if "%APP_NAME_SANITIZED%" == ""             set "APP_NAME_SANITIZED=Nextcloud"
 if "%APPLICATION_NAME%" == ""               set "APPLICATION_NAME=Nextcloud Files Client"
 
 if "%USE_BRANDING%" == ""                   set "USE_BRANDING=0"
-if "%BUILD_TYPE%" == ""                     set "BUILD_TYPE=Release"
+if "%BUILD_TYPE%" == ""                     set "BUILD_TYPE=RelWithDebInfo"
 
 Rem ************************************************************************************************************************************************************************************
 Rem Build environment

--- a/single-build-installer-collect.bat
+++ b/single-build-installer-collect.bat
@@ -134,10 +134,6 @@ if exist "%MY_BUILD_PATH%/src/gui/%APP_NAME_SANITIZED%.ico" (
 )
 if %ERRORLEVEL% neq 0 goto onError
 
-if "%BUILD_TYPE%" == "RelWithDebInfo" (
-    set "PDB_OPTION=--pdb"
-)
-
 echo "* run windeployqt "%MY_COLLECT_PATH%/%APP_NAME_SANITIZED%.exe."
 start "run windeployqt" /D "%MY_COLLECT_PATH%/" /B /wait windeployqt %PDB_OPTION% --compiler-runtime --qmldir "%MY_REPO%\src" --release --force --verbose 2 "%MY_COLLECT_PATH%/%APP_NAME_SANITIZED%.exe" "%MY_COLLECT_PATH%/%APP_NAME_SANITIZED%_csync.dll" "%MY_COLLECT_PATH%/%APP_NAME_SANITIZED%cmd.exe" "%MY_COLLECT_PATH%/%APP_NAME_SANITIZED%sync.dll"
 if %ERRORLEVEL% neq 0 goto onError


### PR DESCRIPTION
we will not include PDB debug symbols files in the MSI installer

this is cusing it to grow too large which is not expected