### PR TITLE
[stable-4.0] Revert "chore: update to new zlib binary DLL name"

### DIFF
--- a/single-build-installer-collect.bat
+++ b/single-build-installer-collect.bat
@@ -183,8 +183,8 @@ start "copy libp11.dll" /D "%MY_COLLECT_PATH%/" /B /wait cp -af "%CRAFT_PATH%/bi
 if %ERRORLEVEL% neq 0 goto
 
 Rem zlib
-echo "* copy z%DLL_SUFFIX%.dll."
-start "copy z%DLL_SUFFIX%.dll" /D "%MY_COLLECT_PATH%/" /B /wait cp -af "%CRAFT_PATH%/bin/z%DLL_SUFFIX%.dll" "%MY_COLLECT_PATH%/"
+echo "* copy zlib1%DLL_SUFFIX%.dll."
+start "copy zlib1%DLL_SUFFIX%.dll" /D "%MY_COLLECT_PATH%/" /B /wait cp -af "%CRAFT_PATH%/bin/zlib1%DLL_SUFFIX%.dll" "%MY_COLLECT_PATH%/"
 if %ERRORLEVEL% neq 0 goto
 
 echo "* copy KArchive files (bin/)."
@@ -271,7 +271,7 @@ if "%USE_CODE_SIGNING%" == "0" (
             "qt6keychain%DLL_SUFFIX%.dll"
             "%LIBCRYPTO_DLL_FILENAME%"
             "%LIBSSL_DLL_FILENAME%"
-            "z%DLL_SUFFIX%.dll"
+            "zlib1%DLL_SUFFIX%.dll"
         ) do (
             start "sign %%~G" /D "%PROJECT_PATH%/" /B /wait %~dp0/sign.bat "%MY_COLLECT_PATH%/%%~G"
 


### PR DESCRIPTION
This reverts commit https://github.com/nextcloud/client-building/commit/49db6611cc516d6f9153eafba9ca3a31f303a934.

See also: https://github.com/nextcloud/desktop/pull/9905